### PR TITLE
第一次用github参与其他项目

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@
 const { app, BrowserWindow } = require('electron')
 const path = require('path')
 const url = require('url')
-const user32 = require('./app/scripts/user32').User32
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -22,8 +21,6 @@ function createWindow() {
     })
 
     win.once('ready-to-show', () => {
-        let hwnd = win.getNativeWindowHandle()
-        user32.GetSystemMenu(hwnd.readUInt32LE(0), true)
         win.show()
     })
 

--- a/app.js
+++ b/app.js
@@ -48,6 +48,17 @@ function createWindow() {
 
         mainWin.loadURL("http://www.baidu.com");
     })
+    //hookWindowMessage 可以拦截窗口消息
+    //int WM_INITMENU = 0x116; //当一个下拉菜单或子菜单将要被激活时发送此消息，它允许程序在它显示前更改菜单，而不要改变全部
+    win.hookWindowMessage(278, function(){
+    win.blur();//可忽略
+    win.focus();//可忽略
+    win.setEnabled(false);//窗口禁用
+    setTimeout(() => {
+      win.setEnabled(true);//窗口启用
+    }, 100);//延时太快会立刻启用，太慢会妨碍窗口其他操作，可自行测试最佳时间
+    return true;
+  })
 }
 
 //app.disableHardwareAcceleration();


### PR DESCRIPTION
见到大神的操作觉得神奇，一切都在打包的时候戛然而止。
用Electron第九天，对于打包不是很熟悉，导致打包出来文件很大。
首先我想到把node模块都从项目里去除。难点在于本项目用user32 GetSystemMenu(hwnd,true);实现菜单屏蔽，在window窗口信息里面这个操作很常规。但是对于我要做的事情却带来了灾难。
如果排除node目录则无法运行，如果引入会导致打包太大。
用了一下午找到了electron-> BrowserWindow-> hookWindowMessage
int WM_INITMENU = 0x116; //当一个下拉菜单或子菜单将要被激活时发送此消息，它允许程序在它显示前更改菜单，而不要改变全部
win.setEnabled(false);//窗口禁用
三者让我成功去掉fs这种依赖实现了同样的功能。
希望对其他人有帮助。我也要补习一下打包的知识。